### PR TITLE
Fix custom command

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "com.ph.nabla_typemath"
         minSdkVersion 26
         targetSdkVersion 34
-        versionCode 13
-        versionName "1.3.3"
+        versionCode 14
+        versionName "1.3.4"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -19,3 +19,19 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+
+#-keep class com.myapplication.model.api.** { *; }
+
+# Gson uses generic type information stored in a class file when working with
+# fields. Proguard removes such information by default, keep it.
+-keepattributes Signature
+
+# This is also needed for R8 in compat mode since multiple
+# optimizations will remove the generic signature such as class
+# merging and argument removal. See:
+# https://r8.googlesource.com/r8/+/refs/heads/main/compatibility-faq.md#troubleshooting-gson-gson
+-keep class com.google.gson.reflect.TypeToken { *; }
+-keep class * extends com.google.gson.reflect.TypeToken
+
+# Optional. For using GSON @Expose annotation
+-keepattributes AnnotationDefault,RuntimeVisibleAnnotations

--- a/app/src/main/java/com/ph/nabla_typemath/CustomCommand.kt
+++ b/app/src/main/java/com/ph/nabla_typemath/CustomCommand.kt
@@ -10,6 +10,7 @@ import androidx.appcompat.app.AppCompatActivity
 
 class CustomCommand : AppCompatActivity() {
 
+//    private val tag = "NablaMathTypeService"
     private val gsonHandler = CustomCommandGSONHandler()
     private var counter = 0
     private var maxIndex = 0
@@ -48,11 +49,13 @@ class CustomCommand : AppCompatActivity() {
     private fun saveToPref(){
         val linkedMap = genLinkedHashMap()
         val gSONStr = gsonHandler.linkedMapToGSONStr(linkedMap)
-        // Log.i(tag, gSONStr)
+//        Log.i(tag, gSONStr)
         val sh : SharedPreferences = getSharedPreferences(prefsName, MODE_PRIVATE)
         val editor = sh.edit()
         editor.putString("customMap", gSONStr)
         editor.apply()
+//        val status = editor.commit()
+//        Log.i(tag, "saved status : $status")
     }
 
 


### PR DESCRIPTION
- Edit proguard rules allowing gson to preserve TypeToken Signature
(https://stackoverflow.com/questions/76224936/google-gson-preserve-generic-signatures)
- make sure listener still exists
for some reason, (maybe because of optimization), even if the listener is stored in `this.listener`, 
if there's no other code referencing it, the listener is yeeted by the GC.

Fix #7 